### PR TITLE
Landing page strike planner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 // import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import { lazy, Suspense } from 'react';
+import PendingInviteHandler from './components/PendingInviteHandler';
 const CityBlitz = lazy(() => import('./pages/V2')); // rename later if desired
 const SharedMapViewer = lazy(() => import('./pages/SharedMapViewer'));
 const FactionStrike = lazy(() => import('./features/strike/FactionStrikePage'));
@@ -21,6 +22,7 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
+        <PendingInviteHandler />
         <Routes>
           <Route path="/" element={<Suspense fallback={<div>Loading...</div>}><CityBlitz /></Suspense>} />
           <Route path="/shared/:shareId" element={<Suspense fallback={<div>Loading shared map...</div>}><SharedMapViewer /></Suspense>} />

--- a/src/components/PendingInviteHandler.tsx
+++ b/src/components/PendingInviteHandler.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { supabase } from '@/services/supabaseClient';
+import { acceptInvite } from '@/services/inviteApi';
+
+function getPendingInvite(): { token: string; next: string } | null {
+  try {
+    const token = localStorage.getItem('pending_invite_token') || '';
+    if (!token) return null;
+    const next = localStorage.getItem('pending_invite_next') || '/faction-strike-planner';
+    return { token, next };
+  } catch {
+    return null;
+  }
+}
+
+function clearPendingInvite() {
+  try {
+    localStorage.removeItem('pending_invite_token');
+    localStorage.removeItem('pending_invite_next');
+  } catch { /* ignore */ }
+}
+
+/**
+ * Handles the case where OAuth redirects to `/` (losing the original `/invite?token=...` URL).
+ * If a pending invite token exists in localStorage and the user is now signed in, accept it and navigate.
+ */
+export default function PendingInviteHandler() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const inFlight = useRef(false);
+
+  useEffect(() => {
+    if (!supabase) return;
+    // Let the dedicated invite page handle itself to avoid double-accept.
+    if (pathname.startsWith('/invite')) return;
+    const pending = getPendingInvite();
+    if (!pending) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
+
+    (async () => {
+      try {
+        const { data: userRes } = await supabase.auth.getUser();
+        const uid = userRes.user?.id;
+        if (!uid) return; // not signed in yet; keep pending
+
+        const res = await acceptInvite(pending.token);
+        localStorage.setItem('current_org', res.org_id);
+        clearPendingInvite();
+        navigate(pending.next, { replace: true });
+      } catch (e: unknown) {
+        const msg = (e instanceof Error ? e.message : '').toLowerCase();
+        if (!msg.includes('not signed in')) {
+          // token is invalid/expired/etc; don't keep retrying forever
+          clearPendingInvite();
+        }
+      } finally {
+        inFlight.current = false;
+      }
+    })();
+  }, [pathname, navigate]);
+
+  return null;
+}
+


### PR DESCRIPTION
Make read-only broadcast invite links reliably land on the Strike Planner.

OAuth redirects often drop users at the site root (`/`) after sign-in, causing invite links to land on the Map Planner instead of the intended Strike Planner. This change ensures the invite token is persisted and processed after login, redirecting the user to the correct planner.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c3a6c11-5039-482a-8294-66347a5060bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c3a6c11-5039-482a-8294-66347a5060bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures invite acceptance completes and redirects to the Strike Planner even when OAuth drops the original invite URL.
> 
> - Adds `PendingInviteHandler` to process `localStorage`-persisted `pending_invite_token` post-login; accepts invite, sets `current_org`, and navigates to the saved `next` path; mounted in `App.tsx` before routes
> - Updates `InvitePage` to persist the invite token/next on "not signed in", initiate OAuth with `redirectTo` set to `window.location.origin`, and improve error handling/types
> - Prevents double-accept by skipping on `/invite` and using an in-flight guard
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79b4c30d209ca5df11d7fa4c6e8fdda938d573bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->